### PR TITLE
Fix target selection using intero-targets

### DIFF
--- a/src/InteroNixShim/Main.hs
+++ b/src/InteroNixShim/Main.hs
@@ -2,6 +2,7 @@ module InteroNixShim.Main where
 
 import           Control.Monad        (when)
 import           Data.Foldable        (find, traverse_)
+import           Data.List            (stripPrefix)
 import qualified Data.List.Split      as S
 import           Data.Maybe           (catMaybes, fromMaybe, maybe)
 import           Data.Semigroup       ((<>))
@@ -64,7 +65,9 @@ run (Ghci opt) = do
   let targets' =
         case targets opt of
           [] -> defaultTarget
-          xs -> xs
+          -- strip project name prefix from stack targets before using as cabal components
+          xs -> fromMaybe xs
+                  $ sequenceA (stripPrefix (projectName ++ ":") <$> xs)
   -- Important: do NOT pass `--verbose=0` to `cabal repl` or users’ errors won’t be shown in Flycheck.
   nixExec $ [cabal, "repl"] ++ ghcSubst ++ ghcOpts ++ targets'
 run Path = putStrLn =<< rootDir

--- a/src/InteroNixShim/Main.hs
+++ b/src/InteroNixShim/Main.hs
@@ -58,9 +58,10 @@ run (Ghci opt) = do
   let ghcOpts = (\o -> ["--ghc-options", o]) =<< ghcOptions opt
   -- Workaround for https://github.com/haskell/cabal/issues/4602 in Cabal 2.×
   (projectName, availableTargets) <- ideTargets'
-  let defaultTarget =
-        if "lib" `elem` availableTargets
-          then ["lib:" ++ projectName]
+  let libName = "lib:" ++ projectName
+      defaultTarget =
+        if libName `elem` availableTargets
+          then [libName]
           else take 1 availableTargets
   let targets' =
         case targets opt of
@@ -147,7 +148,7 @@ ideTargets cabal =
           k:v:_ -> [(k, v)]
           _ -> []
       name = fromMaybe "_" $ snd <$> find (\(k, _) -> k == "name") kvs
-      lib = ["lib" | "library" `elem` lns]
+      lib = ["lib:" ++ name | "library" `elem` lns]
       tpe s l = (++) (s ++ ":") . snd <$> filter (\(k, _) -> k == l) kvs
       exe = tpe "exe" "executable"
       test = tpe "test" "test-suite"


### PR DESCRIPTION
`intero-targets` uses `intero-nix-shim ide targets` to get the list of targets, which lists them in the format

    project:exe:exe-name
    project:lib
    project:test:test-suite-name

etc. This is using the stack target syntax, with a project name on the front. But when you select a target, `intero` passes that back to `intero-nix-shim ghci`, which is using regular `cabal ghci` rather than `stack ghci`. Cabal doesn't understand the project name prefix, so this fails. It wants the components to be specified like:

    exe:exe-name
    lib
    test:test-suite-name

The result is that you can't select a target at all when using `intero-nix-shim`; only the default target works.

This pull request attempts to strip off the expected project name uniformly from all the given targets; if that doesn't work for every listed target, then just use the unmodified target list. That allows me to work on a project with a test suite, and switch the target to the test suite.